### PR TITLE
Add keywords + fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Highlighting for Wollok language
 
-[![GNU General Public License](https://img.shields.io/badge/license-GPL%20v3-orange.svg?style=flat-square)](http://www.gnu.org/licenses/gpl-3.0.en.html) [![Version](https://vsmarketplacebadge.apphb.com/version/uqbar.wollok-highlight.svg)](https://vsmarketplacebadge.apphb.com/version/uqbar.wollok-highlight.svg) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/uqbar.wollok-highlight.svg)](https://vsmarketplacebadge.apphb.com/installs-short/uqbar.wollok-highlight.svg)
+[![GNU General Public License](https://img.shields.io/badge/license-GPL%20v3-orange.svg?style=flat-square)](http://www.gnu.org/licenses/gpl-3.0.en.html) [![Version](https://vsmarketplacebadges.dev/version/uqbar.wollok-highlight.svg)](https://vsmarketplacebadges.dev/version/uqbar.wollok-highlight.svg) [![Installs](https://vsmarketplacebadges.dev/installs-short/uqbar.wollok-highlight.svg)](https://vsmarketplacebadges.dev/installs-short/uqbar.wollok-highlight.svg)
 
 
 This component solves highlighting for Wollok files:

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "wollok-highlight",
   "displayName": "wollok-highlight",
-  "description": "Highlighting for Wollok language",
+  "description": "Wollok Highlighter",
   "author": "Uqbar Foundation",
   "license": "LGPL-3.0",
   "publisher": "uqbar",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uqbar-project/wollok-highlight-vscode.git"

--- a/syntaxes/wollok.textmate
+++ b/syntaxes/wollok.textmate
@@ -107,9 +107,15 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>\b(object|class|package|program|test|describe|method|override|constructor|native|var|const|property|inherits|new|if|else|self|super|import|null|true|false|return|throw|then always|try|catch|mixed with|with|mixin|fixture)\b</string>
+            <string>\b(object|class|package|program|test|describe|method|override|constructor|native|var|const|property|inherits|new|if|else|self|super|import|null|true|false|return|throw|then|always|try|catch|mixed|with|mixin|fixture|only|and)\b</string>
             <key>name</key>
             <string>keyword.wollok</string>
+          </dict>
+          <dict>
+            <key>match</key>
+            <string>(\@[A-Za-z]*)</string>
+            <key>name</key>
+            <string>keyword.meta.wollok</string>
           </dict>
         </array>
       </dict>


### PR DESCRIPTION
En esta versión agregamos algunas keywords que hacían falta

- only
- las annotations
- then always ahora van por separado para que si ponés `then  always` te lo marque

También corregimos los badges de VSC para que se vean en la extensión.
